### PR TITLE
fix #48 added no-results message

### DIFF
--- a/slactwin/package_data/static/html/slactwin-viz.html
+++ b/slactwin/package_data/static/html/slactwin-viz.html
@@ -1,4 +1,5 @@
 <div data-loading-indicator="loadingMessage"></div>
+<div>{{ viz.errorWatch() }}</div>
 <div class="container-fluid" data-ng-if="viz.simState.hasFrames()">
   <div class="row">
     <div data-column-for-aspect-ratio="statAnimation">


### PR DESCRIPTION
Fixes a few initialization bugs:
 - the archive viewer "animation" model is initialized at app startup to avoid a collision with the "liveAnimation"
 - retry sim initialization if the "animation" directory is removed